### PR TITLE
add layerName param falling back to table

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ tilelive.load(uri, (error, source) => { ... });
 
 ## Parameters
 
+The only parameter that is not mapnik specific is:
+
+| *parameter*       | *value*  | *description* | *default* |
+|:------------------|----------|---------------|----------:|
+| layerName         | string   | name of the layer in resulting tiles. | defaults to the table name for backwards compatibility.|
+
+
 Actual list of parameters you can see [here](https://github.com/mapnik/mapnik/wiki/PostGIS).
 
 | *parameter*       | *value*  | *description* | *default* |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "tilelive-postgis",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "tilelive.js adapter for reading from the PostGIS",
   "homepage": "https://github.com/stepankuzmin/tilelive-postgis",
   "author": "Stepan Kuzmin <to.stepan.kuzmin@gmail.com> (stepankuzmin.ru)",

--- a/src/index.js
+++ b/src/index.js
@@ -11,11 +11,11 @@ const srs = '+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y
 const PostgisSource = function PostgisSource(uri, callback) {
   const options = parse(uri);
 
-  const { tableName } = options;
-  delete options.tableName;
+  const { layerName } = options;
+  delete options.layerName;
 
   const datasource = new mapnik.Datasource(options);
-  const layer = new mapnik.Layer(tableName);
+  const layer = new mapnik.Layer(layerName);
   layer.datasource = datasource;
 
   const map = new mapnik.Map(256, 256, srs);
@@ -25,8 +25,8 @@ const PostgisSource = function PostgisSource(uri, callback) {
   this._pool = mapnikPool.fromString(xml);
 
   this._info = {
-    id: tableName,
-    name: tableName,
+    id: layerName,
+    name: layerName,
     format: 'pbf',
     scheme: 'tms',
     bounds: datasource.extent(),

--- a/src/parse.js
+++ b/src/parse.js
@@ -23,6 +23,7 @@ const parse = (uri) => {
   }
 
   const { table, query } = params.query;
+  const layerName = params.query.layerName || table;
 
   const defaultOptions = {
     type: 'postgis',
@@ -31,8 +32,8 @@ const parse = (uri) => {
     dbname,
     user,
     password,
-    tableName: table,
-    table: query || table
+    table: query || table,
+    layerName
   };
 
   return Object.assign({}, params.query, defaultOptions);


### PR DESCRIPTION
Currently, the layerName defaults to tableName here.

It would help to not expose the backend concern of what the table name in DB is, to frontend consumers such as say, mapbox-gl.

Since `tableName` was anyway an internal param, it was easy to refactor the code to switch to the new `layerName`.